### PR TITLE
removed res from logger message

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -32,8 +32,7 @@ exports.run = (appId, secret, cb) => {
       }
     }, (err, res) => {
       if (err || res.statusCode !== 200) {
-        logger.error(`Error (${res.statusCode}) requesting token error '${err}'`)
-        logger.error(res.body)
+        logger.error(`Error requesting token error '${err}'`)
 
         cb(err || new Error(res.statusCode), current)
         return


### PR DESCRIPTION
in the refresh method, an error in the request.post call will cause the logger to write some messages which reference the `res` object.  However, in that code the `res` object doesn't exist so the app will crash. I have removed the references to the res object in the logger statements.